### PR TITLE
Limits.hpp - convert some config consts to #define

### DIFF
--- a/src/Homie/Limits.hpp
+++ b/src/Homie/Limits.hpp
@@ -3,10 +3,14 @@
 #include <ArduinoJson.h>
 
 namespace HomieInternals {
-  const uint16_t MAX_JSON_CONFIG_FILE_SIZE = 1000;
+  #ifndef MAX_JSON_CONFIG_FILE_SIZE
+  #define MAX_JSON_CONFIG_FILE_SIZE 1000
+  #endif
 
   // max setting elements
-  const uint8_t MAX_CONFIG_SETTING_SIZE = 10;
+  #ifndef MAX_CONFIG_SETTING_SIZE
+  #define MAX_CONFIG_SETTING_SIZE 10
+  #endif
   // 6 elements at root, 9 elements at wifi, 6 elements at mqtt, 1 element at ota, max settings elements
   const uint16_t MAX_JSON_CONFIG_ARDUINOJSON_BUFFER_SIZE = JSON_OBJECT_SIZE(6) + JSON_OBJECT_SIZE(9) + JSON_OBJECT_SIZE(6) + JSON_OBJECT_SIZE(1) + JSON_OBJECT_SIZE(MAX_CONFIG_SETTING_SIZE);
 


### PR DESCRIPTION
This patch allows to change this limits from platformio.ini. There is real need to do that, because of user settings count can be more than 10.